### PR TITLE
feat: add alternative fallback placeholders when both images fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ pnpm add next-image-fallback
 
 ## Usage
 
+### Basic Usage
+
 ```tsx
 import { NextImageFallback } from 'next-image-fallback';
 
@@ -34,11 +36,112 @@ export default function AvatarExample() {
 }
 ```
 
+### Alternative Fallback (New Feature!)
+
+When both primary and fallback images fail, you can display a beautiful CSS-based placeholder instead of a broken image icon:
+
+```tsx
+import { NextImageFallback, ALTERNATIVE_FALLBACK } from 'next-image-fallback';
+
+export default function AvatarExample() {
+  return (
+    <NextImageFallback
+      src="https://example.com/avatars/user-123.png"
+      fallbackSrc="/images/avatar-placeholder.png"
+      alt="User avatar"
+      width={128}
+      height={128}
+      // Alternative fallback options
+      alternativeFallback="gradient"  // 'gradient' | 'waves' | 'mono'
+      primaryAltColor="#6366f1"       // Primary color (hex, rgb, or named)
+      secondaryAltColor="#8b5cf6"     // Secondary color for gradient/waves
+      altErrorMessage="Image unavailable"  // Custom error message
+      altTextColor="#ffffff"          // Text color
+      onAlternativeFallback={() => console.log('Showing placeholder')}
+    />
+  );
+}
+```
+
+#### Using Constants
+
+```tsx
+import { NextImageFallback, ALTERNATIVE_FALLBACK } from 'next-image-fallback';
+
+// Use predefined constants
+<NextImageFallback
+  src="/image.png"
+  alt="test"
+  width={200}
+  height={200}
+  alternativeFallback={ALTERNATIVE_FALLBACK.GRADIENT}  // or WAVES, MONO
+/>
+```
+
+#### Alternative Fallback Types
+
+| Type | Description |
+|------|-------------|
+| `gradient` | Smooth diagonal gradient from primary to secondary color |
+| `waves` | Multi-layered radial gradient creating a wave-like effect |
+| `mono` | Solid single-color background using primary color |
+
+#### Custom Color Examples
+
+```tsx
+// Using hex colors
+<NextImageFallback
+  src="/image.png"
+  alt="test"
+  width={200}
+  height={200}
+  alternativeFallback="gradient"
+  primaryAltColor="#ff6b6b"
+  secondaryAltColor="#4ecdc4"
+/>
+
+// Using RGB colors
+<NextImageFallback
+  src="/image.png"
+  alt="test"
+  width={200}
+  height={200}
+  alternativeFallback="waves"
+  primaryAltColor="rgb(99, 102, 241)"
+  secondaryAltColor="rgb(139, 92, 246)"
+/>
+
+// Using named colors
+<NextImageFallback
+  src="/image.png"
+  alt="test"
+  width={200}
+  height={200}
+  alternativeFallback="mono"
+  primaryAltColor="slategray"
+/>
+```
+
 ## Props
 
+### Standard Props
 - All standard `next/image` props are supported (`ImageProps`).
-- `fallbackSrc?: ImageProps['src']` � alternative image to display when the primary one fails.
-- `onFallback?: () => void` � callback fired exactly once when switching to the fallback source.
+
+### Fallback Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `fallbackSrc` | `ImageProps['src']` | - | Alternative image to display when the primary one fails |
+| `onFallback` | `() => void` | - | Callback fired exactly once when switching to the fallback source |
+
+### Alternative Fallback Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `alternativeFallback` | `'gradient' \| 'waves' \| 'mono'` | - | Placeholder type to display when both images fail |
+| `primaryAltColor` | `string` | `'#6366f1'` | Primary color (supports hex, rgb, or named colors) |
+| `secondaryAltColor` | `string` | `'#8b5cf6'` | Secondary color for gradient/waves |
+| `altErrorMessage` | `string` | `'Image unavailable'` | Custom error message displayed on placeholder |
+| `altTextColor` | `string` | `'#ffffff'` | Text color for the error message |
+| `onAlternativeFallback` | `() => void` | - | Callback fired when the alternative fallback is shown |
 
 ## How it works
 
@@ -47,10 +150,13 @@ export default function AvatarExample() {
 - Also checks `naturalWidth === 0` in `onLoadingComplete` for environments where broken images still trigger completion.
 - User-supplied `onError` and `onLoadingComplete` handlers are invoked as well.
 - If both original and fallback fail, it will not loop; the fallback is attempted only once per `src` change.
+- **New:** When `alternativeFallback` is set and both images fail, a CSS-based placeholder is rendered with customizable colors and error message.
 
 ## Why?
 
 `next/image` does not support fallbacks out of the box. Handling `onError` manually across a codebase is noisy, and broken image URLs are common in user-generated content or expired remote assets. `next-image-fallback` provides a lightweight, reusable wrapper so you can add a single `fallbackSrc` prop and move on.
+
+**New:** The alternative fallback feature ensures users never see ugly broken image icons – they see a beautiful, branded placeholder instead.
 
 ## Next.js support (App Router & Pages Router)
 
@@ -63,9 +169,23 @@ Server rendering is unaffected; fallback logic only runs in the browser once the
 - The fallback is attempted only once per `src` change to avoid infinite loops.
 - Image optimization rules from your `next.config.js` still apply; ensure the fallback source is allowed (static asset, public folder, or configured remote).
 - This package targets React 18+ and Next.js 13+.
+- The alternative fallback placeholder uses CSS, so it won't work in contexts where CSS is not supported.
 
-## Developed by nipunarambukkanage
+## TypeScript Support
+
+The package is fully typed. Import types as needed:
+
+```tsx
+import type { 
+  NextImageFallbackProps, 
+  AlternativeFallbackType 
+} from 'next-image-fallback';
+```
+
+## Developed by 
+
+nipunarambukkanage
 
 ## License
 
-MIT � 2025 Nipuna Rambukkanage
+MIT © 2025 Nipuna Rambukkanage

--- a/src/NextImageFallback.tsx
+++ b/src/NextImageFallback.tsx
@@ -1,28 +1,240 @@
 import Image, { type ImageProps } from 'next/image';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, CSSProperties } from 'react';
+
+/**
+ * Alternative fallback type options for when both primary and fallback images fail
+ */
+export type AlternativeFallbackType = 'gradient' | 'waves' | 'mono';
+
+/**
+ * Alternative fallback constants for easy reference
+ */
+export const ALTERNATIVE_FALLBACK = {
+  GRADIENT: 'gradient' as const,
+  WAVES: 'waves' as const,
+  MONO: 'mono' as const,
+};
 
 export interface NextImageFallbackProps extends ImageProps {
+  /** Alternative image source to display when the primary one fails */
   fallbackSrc?: ImageProps['src'];
+  /** Callback fired exactly once when switching to the fallback source */
   onFallback?: () => void;
+  /** 
+   * Alternative fallback type to display when both primary and fallback images fail.
+   * Options: 'gradient' | 'waves' | 'mono'
+   */
+  alternativeFallback?: AlternativeFallbackType;
+  /** Primary color for the alternative fallback background (supports hex, rgb, or named colors) */
+  primaryAltColor?: string;
+  /** Secondary color for the alternative fallback background (supports hex, rgb, or named colors) */
+  secondaryAltColor?: string;
+  /** Custom error message to display on the alternative fallback */
+  altErrorMessage?: string;
+  /** Text color for the error message (supports hex, rgb, or named colors) */
+  altTextColor?: string;
+  /** Callback fired when the alternative fallback is shown */
+  onAlternativeFallback?: () => void;
 }
 
+/**
+ * Default colors and messages for alternative fallbacks
+ */
+const DEFAULT_PRIMARY_COLOR = '#6366f1';
+const DEFAULT_SECONDARY_COLOR = '#8b5cf6';
+const DEFAULT_ERROR_MESSAGE = 'Image unavailable';
+const DEFAULT_TEXT_COLOR = '#ffffff';
+
+/**
+ * Generates inline styles for gradient fallback
+ */
+const getGradientStyles = (
+  primaryColor: string,
+  secondaryColor: string,
+  width: number | string,
+  height: number | string
+): CSSProperties => ({
+  width: typeof width === 'number' ? `${width}px` : width,
+  height: typeof height === 'number' ? `${height}px` : height,
+  background: `linear-gradient(135deg, ${primaryColor} 0%, ${secondaryColor} 100%)`,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '4px',
+  position: 'relative',
+  overflow: 'hidden',
+});
+
+/**
+ * Generates inline styles for waves fallback
+ */
+const getWavesStyles = (
+  primaryColor: string,
+  secondaryColor: string,
+  width: number | string,
+  height: number | string
+): CSSProperties => ({
+  width: typeof width === 'number' ? `${width}px` : width,
+  height: typeof height === 'number' ? `${height}px` : height,
+  background: `
+    radial-gradient(ellipse at 50% 0%, ${primaryColor} 0%, transparent 50%),
+    radial-gradient(ellipse at 100% 50%, ${secondaryColor} 0%, transparent 50%),
+    radial-gradient(ellipse at 0% 100%, ${primaryColor} 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 100%, ${secondaryColor} 0%, transparent 50%),
+    linear-gradient(180deg, ${primaryColor} 0%, ${secondaryColor} 100%)
+  `,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '4px',
+  position: 'relative',
+  overflow: 'hidden',
+});
+
+/**
+ * Generates inline styles for mono fallback
+ */
+const getMonoStyles = (
+  primaryColor: string,
+  width: number | string,
+  height: number | string
+): CSSProperties => ({
+  width: typeof width === 'number' ? `${width}px` : width,
+  height: typeof height === 'number' ? `${height}px` : height,
+  backgroundColor: primaryColor,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '4px',
+  position: 'relative',
+  overflow: 'hidden',
+});
+
+/**
+ * Generates inline styles for error text
+ */
+const getTextStyles = (textColor: string, containerWidth: number | string): CSSProperties => ({
+  color: textColor,
+  fontSize: typeof containerWidth === 'number' && containerWidth < 100 ? '10px' : '14px',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  textAlign: 'center',
+  padding: '8px',
+  wordBreak: 'break-word',
+  maxWidth: '90%',
+  lineHeight: '1.4',
+  fontWeight: 500,
+  textShadow: '0 1px 2px rgba(0, 0, 0, 0.2)',
+});
+
+/**
+ * Generates inline styles for the icon
+ */
+const getIconStyles = (): CSSProperties => ({
+  marginBottom: '4px',
+  opacity: 0.8,
+});
+
+/**
+ * Alternative Fallback Placeholder Component
+ */
+const AlternativeFallbackPlaceholder: React.FC<{
+  type: AlternativeFallbackType;
+  primaryColor: string;
+  secondaryColor: string;
+  textColor: string;
+  errorMessage: string;
+  width: number | string;
+  height: number | string;
+}> = ({ type, primaryColor, secondaryColor, textColor, errorMessage, width, height }) => {
+  const getContainerStyles = (): CSSProperties => {
+    switch (type) {
+      case 'gradient':
+        return getGradientStyles(primaryColor, secondaryColor, width, height);
+      case 'waves':
+        return getWavesStyles(primaryColor, secondaryColor, width, height);
+      case 'mono':
+        return getMonoStyles(primaryColor, width, height);
+      default:
+        return getGradientStyles(primaryColor, secondaryColor, width, height);
+    }
+  };
+
+  const showIcon = typeof width === 'number' ? width >= 60 : true;
+  const showText = typeof width === 'number' ? width >= 80 : true;
+
+  return (
+    <div style={getContainerStyles()} role="img" aria-label={errorMessage}>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        {showIcon && (
+          <svg
+            style={getIconStyles()}
+            width={typeof width === 'number' && width < 100 ? '16' : '24'}
+            height={typeof width === 'number' && width < 100 ? '16' : '24'}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke={textColor}
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+            <circle cx="8.5" cy="8.5" r="1.5" />
+            <polyline points="21 15 16 10 5 21" />
+            <line x1="2" y1="2" x2="22" y2="22" />
+          </svg>
+        )}
+        {showText && (
+          <span style={getTextStyles(textColor, width)}>{errorMessage}</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
 export const NextImageFallback: React.FC<NextImageFallbackProps> = (props) => {
-  const { src, fallbackSrc, onFallback, onError, onLoadingComplete, ...rest } = props;
+  const {
+    src,
+    fallbackSrc,
+    onFallback,
+    onError,
+    onLoadingComplete,
+    alternativeFallback,
+    primaryAltColor = DEFAULT_PRIMARY_COLOR,
+    secondaryAltColor = DEFAULT_SECONDARY_COLOR,
+    altErrorMessage = DEFAULT_ERROR_MESSAGE,
+    altTextColor = DEFAULT_TEXT_COLOR,
+    onAlternativeFallback,
+    width,
+    height,
+    ...rest
+  } = props;
 
   const [currentSrc, setCurrentSrc] = useState<ImageProps['src']>(src);
   const [hasTriedFallback, setHasTriedFallback] = useState(false);
+  const [showAlternativeFallback, setShowAlternativeFallback] = useState(false);
 
   useEffect(() => {
     setCurrentSrc(src);
     setHasTriedFallback(false);
+    setShowAlternativeFallback(false);
   }, [src]);
 
   const handleError: React.ReactEventHandler<HTMLImageElement> = (event) => {
     if (fallbackSrc && !hasTriedFallback && currentSrc !== fallbackSrc) {
+      // Try the fallback image first
       setCurrentSrc(fallbackSrc);
       setHasTriedFallback(true);
       if (onFallback) onFallback();
+    } else if (hasTriedFallback && alternativeFallback) {
+      // Both primary and fallback failed, show alternative fallback
+      setShowAlternativeFallback(true);
+      if (onAlternativeFallback) onAlternativeFallback();
+    } else if (!fallbackSrc && alternativeFallback) {
+      // No fallback provided but alternative fallback is set
+      setShowAlternativeFallback(true);
+      if (onAlternativeFallback) onAlternativeFallback();
     }
+
     if (onError) {
       onError(event);
     }
@@ -41,15 +253,42 @@ export const NextImageFallback: React.FC<NextImageFallbackProps> = (props) => {
       return;
     }
 
+    if (
+      result.naturalWidth === 0 &&
+      hasTriedFallback &&
+      alternativeFallback
+    ) {
+      setShowAlternativeFallback(true);
+      if (onAlternativeFallback) onAlternativeFallback();
+      return;
+    }
+
     if (onLoadingComplete) {
       onLoadingComplete(result as any);
     }
   };
 
+  // Show alternative fallback placeholder if both images failed
+  if (showAlternativeFallback && alternativeFallback) {
+    return (
+      <AlternativeFallbackPlaceholder
+        type={alternativeFallback}
+        primaryColor={primaryAltColor}
+        secondaryColor={secondaryAltColor}
+        textColor={altTextColor}
+        errorMessage={altErrorMessage}
+        width={width || 100}
+        height={height || 100}
+      />
+    );
+  }
+
   return (
     <Image
       {...rest}
       src={currentSrc}
+      width={width}
+      height={height}
       onError={handleError}
       onLoadingComplete={handleLoadingComplete}
     />

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { NextImageFallback } from './NextImageFallback';
-export type { NextImageFallbackProps } from './NextImageFallback';
+export { NextImageFallback, ALTERNATIVE_FALLBACK } from './NextImageFallback';
+export type { NextImageFallbackProps, AlternativeFallbackType } from './NextImageFallback';
 export type { ImageProps } from 'next/image';

--- a/tests/NextImageFallback.test.tsx
+++ b/tests/NextImageFallback.test.tsx
@@ -1,6 +1,6 @@
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
-import { NextImageFallback } from '../src/NextImageFallback';
+import { NextImageFallback, ALTERNATIVE_FALLBACK } from '../src/NextImageFallback';
 
 vi.mock('next/image', () => {
   return {
@@ -107,5 +107,270 @@ describe('NextImageFallback', () => {
     fireEvent.error(img);
     await waitFor(() => expect(img.getAttribute('src')).toContain('/fallback.png'));
     expect(onFallback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('NextImageFallback - Alternative Fallback', () => {
+  it('shows gradient alternative fallback when both primary and fallback fail', async () => {
+    const onAlternativeFallback = vi.fn();
+    const { getByRole, container } = render(
+      <NextImageFallback
+        src="/primary.png"
+        fallbackSrc="/fallback.png"
+        alt="test"
+        width={200}
+        height={200}
+        alternativeFallback="gradient"
+        onAlternativeFallback={onAlternativeFallback}
+      />
+    );
+
+    const img = getByRole('img') as HTMLImageElement;
+    
+    // First error - switches to fallback
+    fireEvent.error(img);
+    await waitFor(() => expect(img.getAttribute('src')).toContain('/fallback.png'));
+
+    // Second error - shows alternative fallback
+    fireEvent.error(img);
+    
+    await waitFor(() => {
+      const placeholder = container.querySelector('[role="img"]') as HTMLElement;
+      expect(placeholder).toBeTruthy();
+      expect(placeholder.style.background).toContain('linear-gradient');
+    });
+    expect(onAlternativeFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows waves alternative fallback with custom colors', async () => {
+    const { getByRole, container } = render(
+      <NextImageFallback
+        src="/primary.png"
+        fallbackSrc="/fallback.png"
+        alt="test"
+        width={200}
+        height={200}
+        alternativeFallback="waves"
+        primaryAltColor="#ff0000"
+        secondaryAltColor="#00ff00"
+      />
+    );
+
+    const img = getByRole('img') as HTMLImageElement;
+    
+    fireEvent.error(img);
+    await waitFor(() => expect(img.getAttribute('src')).toContain('/fallback.png'));
+
+    fireEvent.error(img);
+    
+    await waitFor(() => {
+      const placeholder = container.querySelector('[role="img"]') as HTMLElement;
+      expect(placeholder).toBeTruthy();
+      // Waves uses radial-gradient - check the placeholder rendered correctly
+      expect(placeholder.style.width).toBe('200px');
+      expect(placeholder.style.height).toBe('200px');
+    });
+  });
+
+  it('shows mono alternative fallback', async () => {
+    const { getByRole, container } = render(
+      <NextImageFallback
+        src="/primary.png"
+        fallbackSrc="/fallback.png"
+        alt="test"
+        width={200}
+        height={200}
+        alternativeFallback="mono"
+        primaryAltColor="#333333"
+      />
+    );
+
+    const img = getByRole('img') as HTMLImageElement;
+    
+    fireEvent.error(img);
+    await waitFor(() => expect(img.getAttribute('src')).toContain('/fallback.png'));
+
+    fireEvent.error(img);
+    
+    await waitFor(() => {
+      const placeholder = container.querySelector('[role="img"]') as HTMLElement;
+      expect(placeholder).toBeTruthy();
+      expect(placeholder.style.backgroundColor).toBe('rgb(51, 51, 51)');
+    });
+  });
+
+  it('displays custom error message on alternative fallback', async () => {
+    const customMessage = 'Custom error message';
+    const { getByRole, getByText } = render(
+      <NextImageFallback
+        src="/primary.png"
+        fallbackSrc="/fallback.png"
+        alt="test"
+        width={200}
+        height={200}
+        alternativeFallback="gradient"
+        altErrorMessage={customMessage}
+      />
+    );
+
+    const img = getByRole('img') as HTMLImageElement;
+    
+    fireEvent.error(img);
+    fireEvent.error(img);
+    
+    await waitFor(() => {
+      expect(getByText(customMessage)).toBeTruthy();
+    });
+  });
+
+  it('shows alternative fallback immediately when no fallbackSrc provided', async () => {
+    const onAlternativeFallback = vi.fn();
+    const { getByRole, container } = render(
+      <NextImageFallback
+        src="/primary.png"
+        alt="test"
+        width={200}
+        height={200}
+        alternativeFallback="gradient"
+        onAlternativeFallback={onAlternativeFallback}
+      />
+    );
+
+    const img = getByRole('img') as HTMLImageElement;
+    
+    fireEvent.error(img);
+    
+    await waitFor(() => {
+      const placeholder = container.querySelector('[role="img"]') as HTMLElement;
+      expect(placeholder).toBeTruthy();
+      expect(placeholder.style.background).toContain('linear-gradient');
+    });
+    expect(onAlternativeFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses ALTERNATIVE_FALLBACK constants', async () => {
+    const { getByRole, container } = render(
+      <NextImageFallback
+        src="/primary.png"
+        alt="test"
+        width={200}
+        height={200}
+        alternativeFallback={ALTERNATIVE_FALLBACK.GRADIENT}
+      />
+    );
+
+    const img = getByRole('img') as HTMLImageElement;
+    
+    fireEvent.error(img);
+    
+    await waitFor(() => {
+      const placeholder = container.querySelector('[role="img"]') as HTMLElement;
+      expect(placeholder).toBeTruthy();
+    });
+  });
+
+  it('applies custom text color to error message', async () => {
+    const { getByRole, getByText } = render(
+      <NextImageFallback
+        src="/primary.png"
+        alt="test"
+        width={200}
+        height={200}
+        alternativeFallback="gradient"
+        altTextColor="#ffcc00"
+        altErrorMessage="Test message"
+      />
+    );
+
+    const img = getByRole('img') as HTMLImageElement;
+    
+    fireEvent.error(img);
+    
+    await waitFor(() => {
+      const textElement = getByText('Test message');
+      expect(textElement.style.color).toBe('rgb(255, 204, 0)');
+    });
+  });
+
+  it('respects width and height props for alternative fallback', async () => {
+    const { getByRole, container } = render(
+      <NextImageFallback
+        src="/primary.png"
+        alt="test"
+        width={300}
+        height={150}
+        alternativeFallback="gradient"
+      />
+    );
+
+    const img = getByRole('img') as HTMLImageElement;
+    
+    fireEvent.error(img);
+    
+    await waitFor(() => {
+      const placeholder = container.querySelector('[role="img"]') as HTMLElement;
+      expect(placeholder.style.width).toBe('300px');
+      expect(placeholder.style.height).toBe('150px');
+    });
+  });
+
+  it('resets alternative fallback when src changes', async () => {
+    const { getByRole, container, rerender } = render(
+      <NextImageFallback
+        src="/primary.png"
+        alt="test"
+        width={200}
+        height={200}
+        alternativeFallback="gradient"
+      />
+    );
+
+    const img = getByRole('img') as HTMLImageElement;
+    
+    fireEvent.error(img);
+    
+    await waitFor(() => {
+      const placeholder = container.querySelector('[role="img"]') as HTMLElement;
+      expect(placeholder.style.background).toContain('linear-gradient');
+    });
+
+    rerender(
+      <NextImageFallback
+        src="/new.png"
+        alt="test"
+        width={200}
+        height={200}
+        alternativeFallback="gradient"
+      />
+    );
+
+    await waitFor(() => {
+      const newImg = getByRole('img') as HTMLImageElement;
+      expect(newImg.getAttribute('src')).toContain('/new.png');
+    });
+  });
+
+  it('hides text on small width placeholders', async () => {
+    const { getByRole, container, queryByText } = render(
+      <NextImageFallback
+        src="/primary.png"
+        alt="test"
+        width={50}
+        height={50}
+        alternativeFallback="gradient"
+        altErrorMessage="This should be hidden"
+      />
+    );
+
+    const img = getByRole('img') as HTMLImageElement;
+    
+    fireEvent.error(img);
+    
+    await waitFor(() => {
+      const placeholder = container.querySelector('[role="img"]') as HTMLElement;
+      expect(placeholder).toBeTruthy();
+    });
+    
+    expect(queryByText('This should be hidden')).toBeNull();
   });
 });


### PR DESCRIPTION
- Add alternativeFallback prop with 'gradient', 'waves', 'mono' types
- Add customizable colors (primaryAltColor, secondaryAltColor)
- Add customizable error message (altErrorMessage) and text color (altTextColor)
- Add onAlternativeFallback callback
- Export ALTERNATIVE_FALLBACK constants and AlternativeFallbackType
- Add responsive behavior for small containers
- Add comprehensive tests for new features (10 new tests)
- Update README with complete documentation